### PR TITLE
Trait uses must be FQN

### DIFF
--- a/consistence-coding-standard.md
+++ b/consistence-coding-standard.md
@@ -153,7 +153,7 @@ Namespaces
   * `use` declarations are grouped (separated by a line from other declarations) by their top-level namespace, all types from global namespace are considered one group.
   * Exceptions to this rule:
     * Exceptions are always referenced with fully qualified name (FQN).
-    * Types in `extends` and `implements` are also referenced with FQN.
+    * Types in `extends`, `implements` and used traits are also referenced with FQN.
 
 ```php
 <?php


### PR DESCRIPTION
Using traits in a class is very close relationship to extending another class, so this should follow the same rules as `extends`.