### PR TITLE
Remove rule for separating namespace uses by top-level namespace

### DIFF
--- a/consistence-coding-standard.md
+++ b/consistence-coding-standard.md
@@ -150,7 +150,6 @@ Namespaces
   * `use` declarations are sorted alphabetically.
   * `use` declarations never begin with backslash (`\`).
   * Imported types should be renamed with `use ... as ...;` if the type name is too common or clashes with current domain.
-  * `use` declarations are grouped (separated by a line from other declarations) by their top-level namespace, all types from global namespace are considered one group.
   * Exceptions to this rule:
     * Exceptions are always referenced with fully qualified name (FQN).
     * Types in `extends`, `implements` and used traits are also referenced with FQN.


### PR DESCRIPTION
Separating uses by top-level namespace makes the uses section much more readable, especially with files with lots of uses from different libraries/frameworks. But there is no support for this in IDEs and nor is there much chance that there will be support.