### PR TITLE
Require bool and int in PHPDoc to be consistent with PHP's scalar types

### DIFF
--- a/Consistence/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Consistence/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -27,7 +27,7 @@ class ValidVariableNameSniff extends \PHP_CodeSniffer_Standards_AbstractVariable
 
 	/**
 	 * @param \PHP_CodeSniffer_File $file
-	 * @param integer $stackPointer position of the double quoted string
+	 * @param int $stackPointer position of the double quoted string
 	 */
 	protected function processVariable(PHP_CodeSniffer_File $file, $stackPointer)
 	{
@@ -54,7 +54,7 @@ class ValidVariableNameSniff extends \PHP_CodeSniffer_Standards_AbstractVariable
 	 * @codeCoverageIgnore
 	 *
 	 * @param \PHP_CodeSniffer_File $file
-	 * @param integer $stackPointer position of the double quoted string
+	 * @param int $stackPointer position of the double quoted string
 	 */
 	protected function processMemberVar(PHP_CodeSniffer_File $file, $stackPointer)
 	{
@@ -65,7 +65,7 @@ class ValidVariableNameSniff extends \PHP_CodeSniffer_Standards_AbstractVariable
 	 * @codeCoverageIgnore
 	 *
 	 * @param \PHP_CodeSniffer_File $file
-	 * @param integer $stackPointer position of the double quoted string
+	 * @param int $stackPointer position of the double quoted string
 	 */
 	protected function processVariableInString(PHP_CodeSniffer_File $file, $stackPointer)
 	{

--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -67,6 +67,7 @@
 	<rule ref="Squiz.Commenting.EmptyCatchComment"/>
 	<rule ref="Squiz.Commenting.FunctionComment">
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows"/><!-- @throws are forbidden -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectParamVarName"/><!-- requires long boolean and integer parameters -->
 		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/><!-- collection syntax such as string[] is not supported -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturn"/><!-- enforces incorrect types -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturnNotVoid"/><!-- is not able to detect return types such as string|null as correct -->
@@ -197,6 +198,7 @@
 			<property name="newlinesCountBetweenOpenTagAndDeclare" value="2"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>

--- a/consistence-coding-standard.md
+++ b/consistence-coding-standard.md
@@ -694,8 +694,8 @@ Structure for types and methods:
  * Application annotations (optional)
  *
  * @param string $foo
- * @param integer $bar
- * @return boolean
+ * @param int $bar
+ * @return bool
  * @throws \MyException\BarException
  * @throws \MyException\FooException
  */
@@ -776,8 +776,8 @@ private $foo;
 
 List of allowed types (long variants are used):
 
-* `integer`
-* `boolean`
+* `int`
+* `bool`
 * `string`
 * `float`
 * `double`
@@ -815,7 +815,7 @@ use DateTimeImmutable;
 /**
  * @param \DateTimeImmutable $date calendar date
  * @param string[] $events
- * @param integer|null $interval
+ * @param int|null $interval
  * @return \DateTime
  */
 public function myMethod(DateTimeImmutable $date, array $events, int $interval = null): DateTime
@@ -836,7 +836,7 @@ use DateTime;
 
 /**
  * @param string $foo optional description
- * @param integer $bar optional description
+ * @param int $bar optional description
  * @param \DateTime ...$dates optional description
  */
 public function myMethod(string $foo, int $bar, DateTime ...$dates)

--- a/tests/Sniffs/TestCase.php
+++ b/tests/Sniffs/TestCase.php
@@ -76,7 +76,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * @param \PHP_CodeSniffer_File $resultFile
-	 * @param integer $line
+	 * @param int $line
 	 * @param string $code code used inside sniff to indicate error type
 	 * @param string|null $message match part of text in error message
 	 */
@@ -107,7 +107,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 	 * @param mixed[][][] $errorsForLine
 	 * @param string $code
 	 * @param string|null $message
-	 * @return boolean
+	 * @return bool
 	 */
 	private function hasError(array $errorsForLine, string $code, string $message = null): bool
 	{
@@ -142,7 +142,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
 	/**
 	 * @param mixed[][][][] $errorsForFile
-	 * @param integer $line
+	 * @param int $line
 	 * @return string in format <source>: <message>
 	 */
 	private function getFormattedErrorsOnLine(array $errorsForFile, int $line): string


### PR DESCRIPTION
When Consistence standard was first assembled (around 2013) there was no inclination in PHP, which form (short/long) will be preferred and there were used differently in various places. So for consistence was the choice to go with the more verbose, as stated in the standard.

However with the introduction of scalar type hints in PHP 7, which support only short variants, it is clear which variant is preferred now and hopefully PHP will stick with it in other places.