### PR TITLE
Rules for writing inline `@var`

### DIFF
--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -154,6 +154,7 @@
 	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
 	<rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>
+	<rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.YodaComparison"/>
 	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
 	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>

--- a/consistence-coding-standard.md
+++ b/consistence-coding-standard.md
@@ -860,6 +860,17 @@ public function myMethod(string $foo, int $bar, DateTime ...$dates)
 private $foo;
 ```
 
+* Inline `@var` is used to define types for variables, where the type is not clear.
+  * Uses docblock comment `/** ... */`.
+  * Type is defined first, followed by variable name.
+
+```php
+<?php
+
+/** @var \Foo $foo optional description */
+$foo = $container->getService('foo');
+```
+
 ### @throws
 
 * For implemented methods `@throws` is never used.


### PR DESCRIPTION
Definition of format for writing `@var` to be consistent with other PHPDoc annotations.