### PR TITLE
New sniff Consistence.Exceptions.ExceptionDeclaration checks exception rules from the standard

### DIFF
--- a/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
+++ b/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
@@ -6,12 +6,15 @@ namespace Consistence\Sniffs\Exceptions;
 
 use PHP_CodeSniffer\Files\File as PhpCsFile;
 use SlevomatCodingStandard\Helpers\ClassHelper;
+use SlevomatCodingStandard\Helpers\FunctionHelper;
 use SlevomatCodingStandard\Helpers\StringHelper;
+use SlevomatCodingStandard\Helpers\TokenHelper;
 
 class ExceptionDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 {
 
 	const CODE_NOT_ENDING_WITH_EXCEPTION = 'NotEndingWithException';
+	const CODE_NOT_CHAINABLE = 'NotChainable';
 
 	/**
 	 * @return int[]
@@ -40,6 +43,8 @@ class ExceptionDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 		}
 
 		$this->checkExceptionName($phpcsFile, $classPointer);
+
+		$this->checkThatExceptionIsChainable($phpcsFile, $classPointer);
 	}
 
 	private function checkExceptionName(PhpCsFile $phpcsFile, int $classPointer)
@@ -51,6 +56,60 @@ class ExceptionDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 				$className
 			), $classPointer, self::CODE_NOT_ENDING_WITH_EXCEPTION);
 		}
+	}
+
+	private function checkThatExceptionIsChainable(PhpCsFile $phpcsFile, int $classPointer)
+	{
+		$constructorPointer = $this->findConstructorMethodPointer($phpcsFile, $classPointer);
+		if ($constructorPointer === null) {
+			return;
+		}
+
+		$typeHints = FunctionHelper::getParametersTypeHints($phpcsFile, $constructorPointer);
+		if (count($typeHints) === 0) {
+			$phpcsFile->addError(
+				'Exception is not chainable. It must have optional \Throwable as last constructor argument.',
+				$constructorPointer,
+				self::CODE_NOT_CHAINABLE
+			);
+			return;
+		}
+		$lastArgument = array_pop($typeHints);
+
+		if ($lastArgument === null) {
+			$phpcsFile->addError(
+				'Exception is not chainable. It must have optional \Throwable as last constructor argument and has none.',
+				$constructorPointer,
+				self::CODE_NOT_CHAINABLE
+			);
+			return;
+		}
+
+		if ($lastArgument->getTypeHint() !== '\Throwable') {
+			$phpcsFile->addError(sprintf(
+				'Exception is not chainable. It must have optional \Throwable as last constructor argument and has "%s".',
+				$lastArgument->getTypeHint()
+			), $constructorPointer, self::CODE_NOT_CHAINABLE);
+			return;
+		}
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $classPointer
+	 * @return int|null
+	 */
+	private function findConstructorMethodPointer(PhpCsFile $phpcsFile, int $classPointer)
+	{
+		$functionPointerToScan = $classPointer;
+		while (($functionPointer = TokenHelper::findNext($phpcsFile, T_FUNCTION, $functionPointerToScan)) !== null) {
+			$functionName = FunctionHelper::getName($phpcsFile, $functionPointer);
+			if ($functionName === '__construct') {
+				return $functionPointer;
+			}
+			$functionPointerToScan = $functionPointer + 1;
+		}
+		return null;
 	}
 
 }

--- a/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
+++ b/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+use PHP_CodeSniffer\Files\File as PhpCsFile;
+use SlevomatCodingStandard\Helpers\ClassHelper;
+use SlevomatCodingStandard\Helpers\StringHelper;
+
+class ExceptionDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
+{
+
+	const CODE_NOT_ENDING_WITH_EXCEPTION = 'NotEndingWithException';
+
+	/**
+	 * @return int[]
+	 */
+	public function register(): array
+	{
+		return [
+			T_CLASS,
+			T_INTERFACE,
+		];
+	}
+
+	/**
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
+	 * @param int $classPointer
+	 */
+	public function process(PhpCsFile $phpcsFile, $classPointer)
+	{
+		$extendedClassName = $phpcsFile->findExtendedClassName($classPointer);
+		if ($extendedClassName === false) {
+			return; //does not extend anything
+		}
+
+		if (!StringHelper::endsWith($extendedClassName, 'Exception')) {
+			return; // does not extend Exception, is not an exception
+		}
+
+		$this->checkExceptionName($phpcsFile, $classPointer);
+	}
+
+	private function checkExceptionName(PhpCsFile $phpcsFile, int $classPointer)
+	{
+		$className = ClassHelper::getName($phpcsFile, $classPointer);
+		if (!StringHelper::endsWith($className, 'Exception')) {
+			$phpcsFile->addError(sprintf(
+				'Exception class name "%s" must end with "Exception".',
+				$className
+			), $classPointer, self::CODE_NOT_ENDING_WITH_EXCEPTION);
+		}
+	}
+
+}

--- a/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
+++ b/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
@@ -99,4 +99,47 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 		);
 	}
 
+	public function testExceptionWithConstructorWithoutParametersIsNotChainable()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ConstructWithoutParametersException.php');
+
+		$this->assertSniffError(
+			$resultFile,
+			10,
+			ExceptionDeclarationSniff::CODE_NOT_CHAINABLE,
+			'Exception is not chainable. It must have optional \Throwable as last constructor argument.'
+		);
+	}
+
+	public function testExceptionWithChainableConstructorIsChainable()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ChainableConstructorException.php');
+
+		$this->assertNoSniffError($resultFile, 10);
+	}
+
+	public function testExceptionWithNonchainableConstructorIsNotChainable()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorException.php');
+
+		$this->assertSniffError(
+			$resultFile,
+			10,
+			ExceptionDeclarationSniff::CODE_NOT_CHAINABLE,
+			'Exception is not chainable. It must have optional \Throwable as last constructor argument and has "string".'
+		);
+	}
+
+	public function testExceptionWithConstructorWithoutParameterTypeHintIsNotChainable()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorWithoutParameterTypehintException.php');
+
+		$this->assertSniffError(
+			$resultFile,
+			10,
+			ExceptionDeclarationSniff::CODE_NOT_CHAINABLE,
+			'Exception is not chainable. It must have optional \Throwable as last constructor argument and has none.'
+		);
+	}
+
 }

--- a/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
+++ b/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
@@ -9,7 +9,9 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 
 	public function testInvalidExceptionName()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/InvalidExceptionName.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/InvalidExceptionName.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertSniffError(
 			$resultFile,
@@ -21,28 +23,36 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 
 	public function testValidClassName()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/ValidNameException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidNameException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testValidClassNameThatExtendsCustomException()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/ValidClassNameThatExtendsCustomException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidClassNameThatExtendsCustomException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testAbstractExceptionWithValidNameException()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/AbstractExceptionWithValidNameException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/AbstractExceptionWithValidNameException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testAbstractClassWithInvalidExceptionName()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/AbstractExceptionWithInvalidName.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/AbstractExceptionWithInvalidName.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertSniffError(
 			$resultFile,
@@ -54,42 +64,54 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 
 	public function testClassThatDoesNotExtendAnything()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/ClassThatDoesNotExtendAnything.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/ClassThatDoesNotExtendAnything.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testClassThatExtendsRegularClass()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/ClassThatDoesNotExtendException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/ClassThatDoesNotExtendException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testInterfaceThatDoesNotExtendAnything()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatDoesNotExtendAnything.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatDoesNotExtendAnything.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testInterfaceThatDoesNotExtendAnythingException()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatDoesNotExtendAnythingException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatDoesNotExtendAnythingException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testInterfaceThatExtendsException()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatExtendsException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatExtendsException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 7);
 	}
 
 	public function testInterfaceThatExtendsExceptionIncorrectName()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatExtendsExceptionIncorrectName.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatExtendsExceptionIncorrectName.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertSniffError(
 			$resultFile,
@@ -101,7 +123,9 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 
 	public function testExceptionWithConstructorWithoutParametersIsNotChainable()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/ConstructWithoutParametersException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/ConstructWithoutParametersException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertSniffError(
 			$resultFile,
@@ -113,14 +137,18 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 
 	public function testExceptionWithChainableConstructorIsChainable()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/ChainableConstructorException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/ChainableConstructorException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertNoSniffError($resultFile, 10);
 	}
 
 	public function testExceptionWithNonchainableConstructorIsNotChainable()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertSniffError(
 			$resultFile,
@@ -132,13 +160,65 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 
 	public function testExceptionWithConstructorWithoutParameterTypeHintIsNotChainable()
 	{
-		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorWithoutParameterTypehintException.php');
+		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorWithoutParameterTypehintException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
 
 		$this->assertSniffError(
 			$resultFile,
 			10,
 			ExceptionDeclarationSniff::CODE_NOT_CHAINABLE,
 			'Exception is not chainable. It must have optional \Throwable as last constructor argument and has none.'
+		);
+	}
+
+	public function testExceptionIsPlacedInCorrectDirectory()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidNameException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	/**
+	 * @requires OS WIN
+	 */
+	public function testExceptionIsPlacedInCorrectDirectoryOnWindows()
+	{
+		// PHP_CodeSniffer detects the path with backslashes on Windows
+		$resultFile = $this->checkFile(__DIR__ . '\data\ValidNameException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testExceptionIsPlacedInIncorrectDirectory()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidNameException.php', [
+			'exceptionsDirectoryName' => 'exceptions',
+		]);
+
+		$this->assertSniffError(
+			$resultFile,
+			7,
+			ExceptionDeclarationSniff::CODE_INCORRECT_EXCEPTION_DIRECTORY,
+			'Exception file "ValidNameException.php" must be placed in "exceptions" directory (is in "data").'
+		);
+	}
+
+	public function testExceptionIsPlacedInIncorrectDirectoryCaseSensitively()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidNameException.php', [
+			'exceptionsDirectoryName' => 'Data',
+		]);
+
+		$this->assertSniffError(
+			$resultFile,
+			7,
+			ExceptionDeclarationSniff::CODE_INCORRECT_EXCEPTION_DIRECTORY,
+			'Exception file "ValidNameException.php" must be placed in "Data" directory (is in "data").'
 		);
 	}
 

--- a/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
+++ b/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
+{
+
+	public function testInvalidExceptionName()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/InvalidExceptionName.php');
+
+		$this->assertSniffError(
+			$resultFile,
+			7,
+			ExceptionDeclarationSniff::CODE_NOT_ENDING_WITH_EXCEPTION,
+			'Exception class name "InvalidExceptionName" must end with "Exception".'
+		);
+	}
+
+	public function testValidClassName()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidNameException.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testValidClassNameThatExtendsCustomException()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ValidClassNameThatExtendsCustomException.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testAbstractExceptionWithValidNameException()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/AbstractExceptionWithValidNameException.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testAbstractClassWithInvalidExceptionName()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/AbstractExceptionWithInvalidName.php');
+
+		$this->assertSniffError(
+			$resultFile,
+			7,
+			ExceptionDeclarationSniff::CODE_NOT_ENDING_WITH_EXCEPTION,
+			'Exception class name "AbstractExceptionWithInvalidName" must end with "Exception".'
+		);
+	}
+
+	public function testClassThatDoesNotExtendAnything()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ClassThatDoesNotExtendAnything.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testClassThatExtendsRegularClass()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ClassThatDoesNotExtendException.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testInterfaceThatDoesNotExtendAnything()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatDoesNotExtendAnything.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testInterfaceThatDoesNotExtendAnythingException()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatDoesNotExtendAnythingException.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testInterfaceThatExtendsException()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatExtendsException.php');
+
+		$this->assertNoSniffError($resultFile, 7);
+	}
+
+	public function testInterfaceThatExtendsExceptionIncorrectName()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/InterfaceThatExtendsExceptionIncorrectName.php');
+
+		$this->assertSniffError(
+			$resultFile,
+			7,
+			ExceptionDeclarationSniff::CODE_NOT_ENDING_WITH_EXCEPTION,
+			'Exception class name "InterfaceThatExtendsExceptionIncorrectName" must end with "Exception".'
+		);
+	}
+
+}

--- a/tests/Sniffs/Exceptions/data/AbstractExceptionWithInvalidName.php
+++ b/tests/Sniffs/Exceptions/data/AbstractExceptionWithInvalidName.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+abstract class AbstractExceptionWithInvalidName extends \Exception
+{
+
+}

--- a/tests/Sniffs/Exceptions/data/AbstractExceptionWithValidNameException.php
+++ b/tests/Sniffs/Exceptions/data/AbstractExceptionWithValidNameException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+abstract class AbstractExceptionWithValidNameException extends \Exception
+{
+
+}

--- a/tests/Sniffs/Exceptions/data/ChainableConstructorException.php
+++ b/tests/Sniffs/Exceptions/data/ChainableConstructorException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ChainableConstructorException extends \Exception
+{
+
+	public function __construct(string $foo, \Throwable $e)
+	{
+		parent::__construct($foo, 0, $e);
+	}
+
+}

--- a/tests/Sniffs/Exceptions/data/ClassThatDoesNotExtendAnything.php
+++ b/tests/Sniffs/Exceptions/data/ClassThatDoesNotExtendAnything.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ClassThatDoesNotExtendAnything
+{
+
+}

--- a/tests/Sniffs/Exceptions/data/ClassThatDoesNotExtendException.php
+++ b/tests/Sniffs/Exceptions/data/ClassThatDoesNotExtendException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ClassThatDoesNotExtendException extends \Consistence\Sniffs\Exceptions\NotAnExceptionClass
+{
+
+}

--- a/tests/Sniffs/Exceptions/data/ConstructWithoutParametersException.php
+++ b/tests/Sniffs/Exceptions/data/ConstructWithoutParametersException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ConstructWithoutParametersException extends \Exception
+{
+
+	public function __construct()
+	{
+		parent::__construct('error', 0, null);
+	}
+
+}

--- a/tests/Sniffs/Exceptions/data/InterfaceThatDoesNotExtendAnything.php
+++ b/tests/Sniffs/Exceptions/data/InterfaceThatDoesNotExtendAnything.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+interface InterfaceThatDoesNotExtendAnything
+{
+
+	public function fooMethod(): string;
+
+}

--- a/tests/Sniffs/Exceptions/data/InterfaceThatDoesNotExtendAnythingException.php
+++ b/tests/Sniffs/Exceptions/data/InterfaceThatDoesNotExtendAnythingException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+interface InterfaceThatDoesNotExtendAnythingException
+{
+
+	public function fooMethod(): string;
+
+}

--- a/tests/Sniffs/Exceptions/data/InterfaceThatExtendsException.php
+++ b/tests/Sniffs/Exceptions/data/InterfaceThatExtendsException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+interface InterfaceThatExtendsException extends \Consistence\Sniffs\Exceptions\InterfaceThatDoesNotExtendAnythingException
+{
+
+	public function extraString(): string;
+
+}

--- a/tests/Sniffs/Exceptions/data/InterfaceThatExtendsExceptionIncorrectName.php
+++ b/tests/Sniffs/Exceptions/data/InterfaceThatExtendsExceptionIncorrectName.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+interface InterfaceThatExtendsExceptionIncorrectName extends \Consistence\Sniffs\Exceptions\InterfaceThatDoesNotExtendAnythingException
+{
+
+	public function extraString(): string;
+
+}

--- a/tests/Sniffs/Exceptions/data/InvalidExceptionName.php
+++ b/tests/Sniffs/Exceptions/data/InvalidExceptionName.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class InvalidExceptionName extends \Exception
+{
+
+}

--- a/tests/Sniffs/Exceptions/data/NonChainableConstructorException.php
+++ b/tests/Sniffs/Exceptions/data/NonChainableConstructorException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class NonChainableConstructorException extends \Exception
+{
+
+	public function __construct(string $foo)
+	{
+		parent::__construct($foo, 0, null);
+	}
+
+}

--- a/tests/Sniffs/Exceptions/data/NonChainableConstructorWithoutParameterTypehintException.php
+++ b/tests/Sniffs/Exceptions/data/NonChainableConstructorWithoutParameterTypehintException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class NonChainableConstructorWithoutParameterTypehintException extends \Exception
+{
+
+	public function __construct($foo, $bar)
+	{
+		parent::__construct($foo, 0, null);
+	}
+
+}

--- a/tests/Sniffs/Exceptions/data/ValidClassNameThatExtendsCustomException.php
+++ b/tests/Sniffs/Exceptions/data/ValidClassNameThatExtendsCustomException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ValidClassNameThatExtendsCustomException extends \Consistence\Sniffs\Exceptions\ValidNameException
+{
+
+}

--- a/tests/Sniffs/Exceptions/data/ValidNameException.php
+++ b/tests/Sniffs/Exceptions/data/ValidNameException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ValidNameException extends \Exception
+{
+
+}

--- a/tests/Sniffs/TestCase.php
+++ b/tests/Sniffs/TestCase.php
@@ -22,7 +22,15 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		parent::__construct($name, $data, $dataName);
 	}
 
-	protected function checkFile(string $filePath): PhpCsFile
+	/**
+	 * @param string $filePath
+	 * @param mixed[] $sniffProperties
+	 * @return \PHP_CodeSniffer\Files\File
+	 */
+	protected function checkFile(
+		string $filePath,
+		array $sniffProperties = []
+	): PhpCsFile
 	{
 		if (!is_readable($filePath)) {
 			throw new \Exception(sprintf(
@@ -37,6 +45,10 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 		]);
 
 		$codeSniffer->init();
+
+		if (count($sniffProperties) > 0) {
+			$codeSniffer->ruleset->ruleset[$this->getSniffName()]['properties'] = $sniffProperties;
+		}
 
 		$codeSniffer->ruleset->sniffs = [$this->getSniffClassName() => $this->getSniffClassName()];
 		$codeSniffer->ruleset->populateTokenListeners();


### PR DESCRIPTION
This sniff checks following rules:
- _"Type name always ends with Exception."_
- _"Exceptions are placed in a separate directory called exceptions."_ (configurable as `exceptionsDirectoryName`)
- _"All exceptions should support exceptions chaining (allow optional `\Throwable` as last argument)."_


---
## Todo
- [x] https://github.com/squizlabs/PHP_CodeSniffer/pull/1473


