### PR TITLE
Remove DisallowAlternativePHPTags as they have been removed from PHP 7.0 onwards

### DIFF
--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -14,7 +14,6 @@
 	<rule ref="Generic.NamingConventions.ConstructorName"/>
 	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag"/>
 	<rule ref="Generic.PHP.DeprecatedFunctions"/>
-	<rule ref="Generic.PHP.DisallowAlternativePHPTags"/>
 	<rule ref="Generic.PHP.ForbiddenFunctions"/>
 	<rule ref="Generic.Strings.UnnecessaryStringConcat">
 		<properties>


### PR DESCRIPTION
http://php.net/manual/en/language.basic-syntax.phptags.php