### PR TITLE
Error last argument is considered chainable

### DIFF
--- a/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
+++ b/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
@@ -116,6 +116,7 @@ class ExceptionDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 		if (
 			$lastArgument->getTypeHint() !== '\Throwable'
 			&& !StringHelper::endsWith($lastArgument->getTypeHint(), 'Exception')
+			&& !StringHelper::endsWith($lastArgument->getTypeHint(), 'Error')
 		) {
 			$phpcsFile->addError(sprintf(
 				'Exception is not chainable. It must have optional \Throwable as last constructor argument and has "%s".',

--- a/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
+++ b/tests/Sniffs/Exceptions/ExceptionDeclarationSniffTest.php
@@ -153,6 +153,15 @@ class ExceptionDeclarationSniffTest extends \Consistence\Sniffs\TestCase
 		$this->assertNoSniffError($resultFile, 10);
 	}
 
+	public function testExceptionWithErrorArgumentIsChainable()
+	{
+		$resultFile = $this->checkFile(__DIR__ . '/data/ErrorArgumentChainableConstructorException.php', [
+			'exceptionsDirectoryName' => 'data',
+		]);
+
+		$this->assertNoSniffError($resultFile, 10);
+	}
+
 	public function testExceptionWithNonchainableConstructorIsNotChainable()
 	{
 		$resultFile = $this->checkFile(__DIR__ . '/data/NonChainableConstructorException.php', [

--- a/tests/Sniffs/Exceptions/data/ErrorArgumentChainableConstructorException.php
+++ b/tests/Sniffs/Exceptions/data/ErrorArgumentChainableConstructorException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Consistence\Sniffs\Exceptions;
+
+class ErrorArgumentChainableConstructorException extends \Exception
+{
+
+	public function __construct(string $foo, \TypeError $e)
+	{
+		parent::__construct($foo, 0, $e);
+	}
+
+}


### PR DESCRIPTION
To allow the core `Error` "exceptions" to be handled as chainable.

http://php.net/manual/en/reserved.exceptions.php