### PR TITLE
Arrays indentation sniff

### DIFF
--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <ruleset name="Consistence">
+	<rule ref="Generic.Arrays.ArrayIndent">
+		<exclude name="Generic.Arrays.ArrayIndent.CloseBraceNotNewLine"/><!-- multiline items causes evaluation as multiline array https://github.com/squizlabs/PHP_CodeSniffer/issues/1791 -->
+	</rule>
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 	<rule ref="Generic.Classes.DuplicateClassName"/>
 	<rule ref="Generic.CodeAnalysis.EmptyStatement">


### PR DESCRIPTION
`Generic.Arrays.ArrayIndent`
* checks multiline arrays indentations
* for now detection of close brace indentation has to be turned off because of https://github.com/squizlabs/PHP_CodeSniffer/issues/1791