### PR TITLE
Remove Squiz.WhiteSpace.ControlStructureSpacing since there should be no error codes left for checking

### DIFF
--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -216,12 +216,6 @@
 	</rule>
 	<rule ref="Squiz.Strings.EchoedStrings"/>
 	<rule ref="Squiz.WhiteSpace.CastSpacing"/>
-	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing">
-		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.NoLineAfterClose"/><!-- we want to allow code directly after if for example -->
-		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/><!-- we want to allow empty line in control structure e.g. in catch blocks, where it can improve readability -->
-		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpenBrace"/><!-- we want to put first expression of multiline condition on next line -->
-		<exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/><!-- we want to allow empty line in control structure e.g. in try blocks, where it can improve readability -->
-	</rule>
 	<rule ref="Squiz.WhiteSpace.FunctionOpeningBraceSpace"/>
 	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
 		<exclude name="Squiz.WhiteSpace.FunctionSpacing.After"/><!-- does not allow PHPUnit ignore comments -->


### PR DESCRIPTION
Added accidentaly in [PSR2 refactoring](https://github.com/consistence/coding-standard/commit/3e0f2d3920d9442e1dc67dc69e0ac2196b5cd739).