### PR TITLE
Check PHPDoc and typehints declaration

### DIFF
--- a/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
+++ b/Consistence/Sniffs/Exceptions/ExceptionDeclarationSniff.php
@@ -32,6 +32,8 @@ class ExceptionDeclarationSniff implements \PHP_CodeSniffer\Sniffs\Sniff
 	}
 
 	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 *
 	 * @param \PHP_CodeSniffer\Files\File $phpcsFile
 	 * @param int $classPointer
 	 */

--- a/Consistence/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/Consistence/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -26,6 +26,8 @@ class ValidVariableNameSniff extends \PHP_CodeSniffer\Sniffs\AbstractVariableSni
 	];
 
 	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+	 *
 	 * @param \PHP_CodeSniffer\Files\File $file
 	 * @param int $stackPointer position of the double quoted string
 	 */
@@ -51,6 +53,7 @@ class ValidVariableNameSniff extends \PHP_CodeSniffer\Sniffs\AbstractVariableSni
 	}
 
 	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
 	 * @codeCoverageIgnore
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $file
@@ -62,6 +65,7 @@ class ValidVariableNameSniff extends \PHP_CodeSniffer\Sniffs\AbstractVariableSni
 	}
 
 	/**
+	 * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
 	 * @codeCoverageIgnore
 	 *
 	 * @param \PHP_CodeSniffer\Files\File $file

--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -137,6 +137,14 @@
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+		<properties>
+			<property name="allAnnotationsAreUseful" value="true"/>
+			<property name="traversableTypeHints" type="array">
+				<element value="Traversable"/>
+			</property>
+		</properties>
+	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
 	<rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces"/>
 	<rule ref="Squiz.Arrays.ArrayBracketSpacing">

--- a/build/cs-ruleset.xml
+++ b/build/cs-ruleset.xml
@@ -9,4 +9,9 @@
 			"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+		<properties>
+			<property name="enableObjectTypeHint" value="false"/><!-- requires 7.2+ -->
+		</properties>
+	</rule>
 </ruleset>


### PR DESCRIPTION
* check for missing property types in PHPDoc `@var`
* check for missing typehints in case they can be declared
* check for missing `@return` and/or native return typehint in case the method body contains return with a value
* check for useless doc comments
* forces to specify what's in traversable types like `array`, `iterable` and `\Traversable`