### PR TITLE
Fix Slevomat Coding Standard dependency to support minor versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"require": {
 		"php": "~7.2",
 		"squizlabs/php_codesniffer": "~3.5.5",
-		"slevomat/coding-standard": "~6.0.0"
+		"slevomat/coding-standard": "~6.0"
 	},
 	"require-dev": {
 		"jakub-onderka/php-console-highlighter": "0.4",


### PR DESCRIPTION
See #62

This adds support for all upcoming minor versions of `slevomat/coding-standard`.