### PR TITLE
Disable errors with false positives in Squiz.Arrays.ArrayDeclaration

### DIFF
--- a/Consistence/ruleset.xml
+++ b/Consistence/ruleset.xml
@@ -181,11 +181,13 @@
 		<exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/><!-- we don't want spacing with alignment -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.FirstIndexNoNewline"/><!-- expects multi-value array always written on multiple lines -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.FirstValueNoNewline"/><!-- expects multi-value array always written on multiple lines -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.IndexNoNewline"/><!-- false positives with nested arrays https://github.com/squizlabs/PHP_CodeSniffer/issues/2937#issuecomment-615262067 -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.KeyNotAligned"/><!-- uses indentation of only single space -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/><!-- even a single-value array can be written on multiple lines -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.NoComma"/><!-- does not handle nested array access with complex keys on multiple lines; also already checked better by SlevomatCodingStandard.Arrays.TrailingArrayComma -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast"/><!-- expects multi-value array always written on multiple lines -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/><!-- multiple values can be written on a single line -->
+		<exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline"/><!-- false positives with nested arrays https://github.com/squizlabs/PHP_CodeSniffer/issues/2937#issuecomment-615262067 -->
 		<exclude name="Squiz.Arrays.ArrayDeclaration.ValueNotAligned"/><!-- we don't want spacing with alignment -->
 	</rule>
 	<rule ref="Squiz.Classes.ClassFileName"/>

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": "~7.2",
-		"squizlabs/php_codesniffer": "~3.5.0",
+		"squizlabs/php_codesniffer": "~3.5.5",
 		"slevomat/coding-standard": "~6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
False positives in PHPCS 3.5.5 https://github.com/squizlabs/PHP_CodeSniffer/issues/2937#issuecomment-615262067