### PR TITLE
⬆️  Upgrade PHP dependency to support PHP8 installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ sudo: false
 php:
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 env:
-  - # default environment without variables
   - COMPOSER_DEPENDENCIES_OPTIONS="--prefer-lowest --prefer-stable"
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": "~7.2",
+		"php": ">=7.2",
 		"squizlabs/php_codesniffer": "~3.5.5",
 		"slevomat/coding-standard": "~6.0"
 	},


### PR DESCRIPTION
The release of PHP8 alpha approaching, it will be nice if the lib authorize installation without tweaking composer installation.

Release `3.10.2` is needed too along the merge