### PR TITLE
Use caret operator where possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
 		}
 	],
 	"require": {
-		"php": "~7.2",
+		"php": "^7.2",
 		"ext-tokenizer": "*",
 		"squizlabs/php_codesniffer": "~3.5.5",
-		"slevomat/coding-standard": "~6.0"
+		"slevomat/coding-standard": "^6.0"
 	},
 	"require-dev": {
 		"phing/phing": "2.17.2",


### PR DESCRIPTION
> "squizlabs/php_codesniffer": "~3.5.5",

In the past `phpcs` released BC breaks in minor versions many times, so leaving on only patch updates.